### PR TITLE
Publish only if parsing succeeds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 script:
 - npm run build
-- node build.js
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then node build.js && npm run publish; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then node build.js; fi'
 - npm run build:postman
-- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run publish; fi'
 
 cache:
   directories:


### PR DESCRIPTION
Actually there are two prerequisites for publishing to
apiary:

  - The build isn't for a pull request (already existed)
  - The parsing step must succeed. This means that we have
    a valid api blueprint file and it will render properly
    when we publish to apiary.