### PR TITLE
Add support for publishing to apiary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
           command: |
             env | grep CIRCLE
             npm run build
-            if [ -n "$CIRCLE_PULL_REQUEST" ]; then node build.js; fi
-            if [ -z "$CIRCLE_PULL_REQUEST" ]; then node build.js && npm run publish; fi
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then node build.js; fi
+            if [ -z "$CIRCLE_PR_NUMBER" ]; then node build.js && npm run publish; fi
             node build.js
             npm run build:postman
             npm run preview

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,8 @@ jobs:
           name: Build
           command: |
             npm run build
+            if [ -n "$CIRCLE_PULL_REQUEST" ]; then node build.js; fi
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then node build.js && npm run publish; fi
             node build.js
             npm run build:postman
             npm run preview

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
       - run:
           name: Build
           command: |
+            env | grep CIRCLE
             npm run build
             if [ -n "$CIRCLE_PULL_REQUEST" ]; then node build.js; fi
             if [ -z "$CIRCLE_PULL_REQUEST" ]; then node build.js && npm run publish; fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ jobs:
       - run:
           name: Build
           command: |
-            env | grep CIRCLE
             npm run build
             if [ -n "$CIRCLE_PR_NUMBER" ]; then node build.js; fi
             if [ -z "$CIRCLE_PR_NUMBER" ]; then node build.js && npm run publish; fi


### PR DESCRIPTION
On a successful build, on a non-PR build,
publish the index.apib file to apiary.

Currently this is just the v1 (alderaan) version.